### PR TITLE
Fix README template links

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -10,13 +10,13 @@
 
 ## License & Copyright
 
-[Modelled on [project guidelines template](./PROJECT.md#license--copyright-readme-block) ]
+[Modelled on [project guidelines template](/datatogether/roadmap/blob/master/PROJECT.md#license--copyright-readme-block) ]
 
 ## Getting Involved
 
-We would love involvement from more people! If you notice any errors or would like to submit changes, please see our [Contributing Guidelines](./CONTRIBUTING.md). 
+We would love involvement from more people! If you notice any errors or would like to submit changes, please see our [Contributing Guidelines](./.github/CONTRIBUTING.md). 
 
-We use GitHub issues for [tracking bugs and feature requests](./issues) and Pull Requests (PRs) for [submitting changes](./pulls)
+We use GitHub issues for [tracking bugs and feature requests](/datatogether/REPONAME/issues) and Pull Requests (PRs) for [submitting changes](/datatogether/REPONAME/pulls)
 
 ## ...
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -10,13 +10,13 @@
 
 ## License & Copyright
 
-[Modelled on [project guidelines template](/datatogether/roadmap/blob/master/PROJECT.md#license--copyright-readme-block) ]
+[Modelled on [project guidelines template](https://github.com/datatogether/roadmap/blob/master/PROJECT.md#license--copyright-readme-block) ]
 
 ## Getting Involved
 
 We would love involvement from more people! If you notice any errors or would like to submit changes, please see our [Contributing Guidelines](./.github/CONTRIBUTING.md). 
 
-We use GitHub issues for [tracking bugs and feature requests](/datatogether/REPONAME/issues) and Pull Requests (PRs) for [submitting changes](/datatogether/REPONAME/pulls)
+We use GitHub issues for [tracking bugs and feature requests](https://github.com/datatogether/REPONAME/issues) and Pull Requests (PRs) for [submitting changes](https://github.com/datatogether/REPONAME/pulls)
 
 ## ...
 


### PR DESCRIPTION
the links in the README template files didn't work in  every context from which the README might be accessed. So we had to make them into absolute URLs, which means they need to be updated for every repository 😢 . 