### PR TITLE
Minor grammar & punctuation edits

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -7,9 +7,9 @@ Each project repository **requires**, at a minimum:
 1. Contributing Guidelines — `.github/CONTRIBUTING.md`
 1. Issue Template — `.github/ISSUE_TEMPLATE.md`
 
-## Readme File
+## Readme
 
-Each [README](https://en.wikipedia.org/wiki/README) file follows a [`README.md` template](./templates/README.md).
+Each [**README**](https://en.wikipedia.org/wiki/README) file follows a [`README.md` template](./templates/README.md).
 
 ## License
 
@@ -20,10 +20,10 @@ Each [README](https://en.wikipedia.org/wiki/README) file follows a [`README.md` 
 for creative works and documentation.
 
 We also use a [License and Copyright block](#license--copyright-readme-block),
-added to our READMEs.  We also add a [LICENSE](/LICENSE) file to the repo, and occasionally
-include a [Code Header License block](#code-header-license-block).
+added to our READMEs.  We also add a [LICENSE](/LICENSE) file to the repo, and 
+occasionally include a [Code Header License block](#code-header-license-block).
 
-### License & Copyright block for README files
+### License & Copyright block for READMEs
 
 ```markdown
 ## License & Copyright
@@ -70,4 +70,4 @@ The template can be extended to cover project- or repo- specific requirements.
 - Golang repository names, folders, and code should be lowercase snakecase (`like_this`)
 - Readme, license, and "github files" should be UPPERCASE (e.g., `CONDUCT.md`, `README.md`, `CONTRIBUTING.md`, `ISSUE_TEMPLATE.md`, `LICENSE`)
 - We hide GitHub stuff (`CONTRIBUTING.md`, `ISSUE_TEMPLATE.md`) in a `.github` folder within every repository
-- Aside from code, en-dashes "-" are fine for many things – including GitHub labels, tags, and more!
+- Aside from code, en-dashes "-" are fine for many things including GitHub labels, tags, and more!

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -28,8 +28,9 @@ include a [Code Header License block](#code-header-license-block).
 ```markdown
 ## License & Copyright
 
-Copyright (C) <year> Data Together.
-This program is free software; you can redistribute it and/or modify it under
+Copyright (C) <year> Data Together
+
+This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software
 Foundation, version 3.0.
 
@@ -44,8 +45,9 @@ See the [`LICENSE`](./LICENSE) file for details.
 
 ```
 /**
- * Copyright (C) <year(s)> Data Together.
- * This program is free software; you can redistribute it and/or modify it
+ * Copyright (C) <year(s)> Data Together
+ *
+ * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation, version 3.0.
  *

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -2,34 +2,34 @@
 
 Each project repository **requires**, at a minimum:
 
-1. Readme -- `README.md`
-1. License -- `LICENSE`
-1. Contributing Guidelines -- `.github/CONTRIBUTING.md`
-1. Issue Template -- `.github/ISSUE_TEMPLATE.md`
+1. Readme — `README.md`
+1. License — `LICENSE`
+1. Contributing Guidelines — `.github/CONTRIBUTING.md`
+1. Issue Template — `.github/ISSUE_TEMPLATE.md`
 
-## Readme
+## Readme File
 
-Each **readme** follows a [`README.md` template](./templates/README.md)
+Each [README](https://en.wikipedia.org/wiki/README) file follows a [`README.md` template](./templates/README.md).
 
 ## License
 
-[GPLv3](http://gplv3.fsf.org/)--or
+[GPLv3](http://gplv3.fsf.org/)—or
 [AGPLv3](http://www.gnu.org/licenses/agpl-3.0.html) ([_why Affero?_
-](http://www.gnu.org/licenses/why-affero-gpl.html))--is our _preferred_
+](http://www.gnu.org/licenses/why-affero-gpl.html))—is our _preferred_
 **license** for code, and [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/)
 for creative works and documentation.
 
 We also use a [License and Copyright block](#license--copyright-readme-block),
-added to our READMEs, add a [LICENSE](/LICENSE) to the repo, and occasionally
+added to our READMEs.  We also add a [LICENSE](/LICENSE) file to the repo, and occasionally
 include a [Code Header License block](#code-header-license-block).
 
-### License & Copyright README block
+### License & Copyright block for README files
 
 ```markdown
 ## License & Copyright
 
-Copyright (C) <year> Data Together
-This program is free software: you can redistribute it and/or modify it under
+Copyright (C) <year> Data Together.
+This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software
 Foundation, version 3.0.
 
@@ -44,8 +44,8 @@ See the [`LICENSE`](./LICENSE) file for details.
 
 ```
 /**
- * Copyright (C) <year(s)> Data Together
- * This program is free software: you can redistribute it and/or modify it
+ * Copyright (C) <year(s)> Data Together.
+ * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation, version 3.0.
  *
@@ -59,13 +59,13 @@ See the [`LICENSE`](./LICENSE) file for details.
 
 We use a [`CONTRIBUTING.md` template](./templates/CONTRIBUTING.md) that points
 to our main **Contributing Guidelines** located in
-[`datatogether/datatogether`](https://github.com/datatogether/datatogether/blob/master/CONDUCT.md),
-the template can be extended to cover project- or repo- specific requirements.
+[`datatogether/datatogether`](https://github.com/datatogether/datatogether/blob/master/CONDUCT.md).
+The template can be extended to cover project- or repo- specific requirements.
 
 ## Style Guidelines
 
 - Our project name is "Data Together" with a space between the words
 - Golang repository names, folders, and code should be lowercase snakecase (`like_this`)
-- Readme, license, and "github files" should be UPPERCASE (e.g. `CONDUCT.md`, `README.md`, `CONTRIBUTING.md`, `ISSUE_TEMPLATE.md`, `LICENSE`)
+- Readme, license, and "github files" should be UPPERCASE (e.g., `CONDUCT.md`, `README.md`, `CONTRIBUTING.md`, `ISSUE_TEMPLATE.md`, `LICENSE`)
 - We hide GitHub stuff (`CONTRIBUTING.md`, `ISSUE_TEMPLATE.md`) in a `.github` folder within every repository
-- Aside from code, en-dashes "-" are fine for many things - including GitHub labels, tags, and more!
+- Aside from code, en-dashes "-" are fine for many things – including GitHub labels, tags, and more!


### PR DESCRIPTION
This encompasses the template changes we discussed earlier during the Google Hangout for the sprint. The license text changes addresses a couple of punctuation issues that showed up repeatedly in the new readme files generated yesterday and today. The remaining changes are just drive-by copy editing while I was touching this file.